### PR TITLE
Add icosphere mesh generator and tests

### DIFF
--- a/.agent/plan.md
+++ b/.agent/plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+1. Set up CMake project structure with library and tests.
+2. Implement CPU icosphere generator in C++20 (header + source).
+3. Provide main program placeholder that uses generator.
+4. Add unit tests verifying vertex counts.
+5. Document build instructions in README.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.25)
+project(vulkan_app VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include(FetchContent)
+FetchContent_Declare(
+  glm
+  GIT_REPOSITORY https://github.com/g-truc/glm.git
+  GIT_TAG 1.0.1
+)
+FetchContent_MakeAvailable(glm)
+
+if (MSVC)
+  add_compile_options(/W4 /permissive-)
+else()
+  add_compile_options(-Wall -Wextra -Wpedantic -Wconversion)
+endif()
+
+add_library(vulkan_app STATIC
+    src/icosphere.cpp
+)
+
+target_sources(vulkan_app
+    PUBLIC
+        FILE_SET HEADERS
+        BASE_DIRS include
+        FILES
+            include/vulkan_app/icosphere.hpp
+)
+
+target_include_directories(vulkan_app PUBLIC include)
+target_link_libraries(vulkan_app PUBLIC glm)
+
+add_executable(vulkan_app_example src/main.cpp)
+target_link_libraries(vulkan_app_example PRIVATE vulkan_app)
+
+include(CTest)
+if (BUILD_TESTING)
+  enable_testing()
+  include(FetchContent)
+  FetchContent_Declare(
+    catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.4.0
+  )
+  FetchContent_MakeAvailable(catch2)
+  add_executable(icosphere_tests tests/icosphere_tests.cpp)
+  target_link_libraries(icosphere_tests PRIVATE Catch2::Catch2WithMain vulkan_app)
+  add_test(NAME icosphere_tests COMMAND icosphere_tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# vulkano
+# Vulkano
+
+Minimal C++20 project demonstrating an icosphere mesh generator.
+
+## Build
+
+```
+cmake -S . -B build
+cmake --build build
+```
+
+## Test
+
+```
+ctest --test-dir build
+```

--- a/include/vulkan_app/icosphere.hpp
+++ b/include/vulkan_app/icosphere.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include <glm/glm.hpp>
+
+namespace vulkan_app {
+
+struct Vertex final {
+    glm::vec3 position{};
+    glm::vec3 normal{};
+    glm::vec2 uv{};
+    glm::vec3 tangent{};
+    glm::vec3 bitangent{};
+};
+
+struct Mesh final {
+    std::vector<Vertex> vertices{};
+    std::vector<std::uint32_t> indices{};
+};
+
+[[nodiscard]] Mesh make_icosphere(int subdivisions);
+
+} // namespace vulkan_app

--- a/src/icosphere.cpp
+++ b/src/icosphere.cpp
@@ -1,0 +1,94 @@
+#include <cmath>
+#include <numbers>
+#include <unordered_map>
+
+#include <glm/glm.hpp>
+#include <glm/geometric.hpp>
+
+#include <vulkan_app/icosphere.hpp>
+
+namespace vulkan_app {
+namespace {
+
+using Edge = std::pair<std::uint32_t, std::uint32_t>;
+
+struct EdgeHash final {
+    [[nodiscard]] std::size_t operator()(const Edge &e) const noexcept {
+        return static_cast<std::size_t>(e.first) << 32U | e.second;
+    }
+};
+
+std::uint32_t midpoint(std::uint32_t a,
+                       std::uint32_t b,
+                       std::vector<glm::vec3> &verts,
+                       std::unordered_map<Edge, std::uint32_t, EdgeHash> &cache) {
+    const Edge key {std::min(a, b), std::max(a, b)};
+    const auto it = cache.find(key);
+    if (it != cache.end()) {
+        return it->second;
+    }
+    const glm::vec3 mid {glm::normalize((verts[a] + verts[b]) * 0.5F)};
+    verts.push_back(mid);
+    const std::uint32_t idx {static_cast<std::uint32_t>(verts.size() - 1U)};
+    cache[key] = idx;
+    return idx;
+}
+
+} // namespace
+
+Mesh make_icosphere(const int subdivisions) {
+    const float t {(1.F + std::sqrt(5.F)) * 0.5F};
+    std::vector<glm::vec3> positions {
+        {-1.F,  t,  0.F}, {1.F,  t,  0.F}, {-1.F, -t,  0.F}, {1.F, -t,  0.F},
+        {0.F, -1.F,  t}, {0.F,  1.F,  t}, {0.F, -1.F, -t}, {0.F,  1.F, -t},
+        { t,  0.F, -1.F}, { t,  0.F,  1.F}, {-t,  0.F, -1.F}, {-t,  0.F,  1.F}
+    };
+    for (auto &p : positions) {
+        p = glm::normalize(p);
+    }
+
+    std::vector<std::array<std::uint32_t, 3U>> faces {
+        {0, 11, 5}, {0, 5, 1}, {0, 1, 7}, {0, 7, 10}, {0, 10, 11},
+        {1, 5, 9}, {5, 11, 4}, {11, 10, 2}, {10, 7, 6}, {7, 1, 8},
+        {3, 9, 4}, {3, 4, 2}, {3, 2, 6}, {3, 6, 8}, {3, 8, 9},
+        {4, 9, 5}, {2, 4, 11}, {6, 2, 10}, {8, 6, 7}, {9, 8, 1}
+    };
+
+    for (int i {0}; i < subdivisions; ++i) {
+        std::unordered_map<Edge, std::uint32_t, EdgeHash> cache {};
+        std::vector<std::array<std::uint32_t, 3U>> next {};
+        next.reserve(faces.size() * 4U);
+        for (const auto &tri : faces) {
+            const auto a = midpoint(tri[0], tri[1], positions, cache);
+            const auto b = midpoint(tri[1], tri[2], positions, cache);
+            const auto c = midpoint(tri[2], tri[0], positions, cache);
+            next.push_back({tri[0], a, c});
+            next.push_back({tri[1], b, a});
+            next.push_back({tri[2], c, b});
+            next.push_back({a, b, c});
+        }
+        faces = std::move(next);
+    }
+
+    Mesh mesh {};
+    mesh.vertices.resize(positions.size());
+    for (std::size_t i {0}; i < positions.size(); ++i) {
+        const glm::vec3 n {glm::normalize(positions[i])};
+        const float u {std::atan2(n.z, n.x) / (2.F * std::numbers::pi_v<float>) + 0.5F};
+        const float v {n.y * 0.5F + 0.5F};
+        const glm::vec3 tangent {glm::normalize(glm::vec3 {-n.z, 0.F, n.x})};
+        const glm::vec3 bitangent {glm::normalize(glm::cross(n, tangent))};
+        mesh.vertices[i] = Vertex {positions[i], n, {u, v}, tangent, bitangent};
+    }
+
+    mesh.indices.reserve(faces.size() * 3U);
+    for (const auto &tri : faces) {
+        mesh.indices.push_back(tri[0]);
+        mesh.indices.push_back(tri[1]);
+        mesh.indices.push_back(tri[2]);
+    }
+
+    return mesh;
+}
+
+} // namespace vulkan_app

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include <vulkan_app/icosphere.hpp>
+
+int main() {
+    const auto mesh {vulkan_app::make_icosphere(0)};
+    std::cout << "vertices: " << mesh.vertices.size() << '\n';
+    return 0;
+}

--- a/tests/icosphere_tests.cpp
+++ b/tests/icosphere_tests.cpp
@@ -1,0 +1,13 @@
+#include <catch2/catch_all.hpp>
+
+#include <vulkan_app/icosphere.hpp>
+
+TEST_CASE("Icosphere vertex and index counts", "[icosphere]") {
+    const auto mesh0 {vulkan_app::make_icosphere(0)};
+    REQUIRE(mesh0.vertices.size() == 12);
+    REQUIRE(mesh0.indices.size() == 60);
+
+    const auto mesh1 {vulkan_app::make_icosphere(1)};
+    REQUIRE(mesh1.vertices.size() == 42);
+    REQUIRE(mesh1.indices.size() == 240);
+}


### PR DESCRIPTION
## Summary
- add CMake project scaffold with Catch2 and glm
- implement CPU icosphere mesh generator
- provide example app and basic documentation
- add unit tests for vertex/index counts

## Testing
- `cmake -S . -B build` *(fails: unable to clone glm repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c7df9d4204832781aca401e3f9f837