### PR TITLE
Add basic Vulkan GLFW application skeleton

### DIFF
--- a/.agent/plan.md
+++ b/.agent/plan.md
@@ -5,3 +5,6 @@
 3. Provide main program placeholder that uses generator.
 4. Add unit tests verifying vertex counts.
 5. Document build instructions in README.
+6. Integrate GLFW and Vulkan to open a window.
+7. Implement `Application` class managing instance and window lifetime.
+8. Replace placeholder `main` with `Application` usage.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(glm)
 
+FetchContent_Declare(
+  glfw
+  GIT_REPOSITORY https://github.com/glfw/glfw.git
+  GIT_TAG 3.3.8
+)
+FetchContent_MakeAvailable(glfw)
+
+find_package(Vulkan REQUIRED)
+
 if (MSVC)
   add_compile_options(/W4 /permissive-)
 else()
@@ -21,6 +30,7 @@ endif()
 
 add_library(vulkan_app STATIC
     src/icosphere.cpp
+    src/application.cpp
 )
 
 target_sources(vulkan_app
@@ -29,10 +39,11 @@ target_sources(vulkan_app
         BASE_DIRS include
         FILES
             include/vulkan_app/icosphere.hpp
+            include/vulkan_app/application.hpp
 )
 
 target_include_directories(vulkan_app PUBLIC include)
-target_link_libraries(vulkan_app PUBLIC glm)
+target_link_libraries(vulkan_app PUBLIC glm glfw Vulkan::Vulkan)
 
 add_executable(vulkan_app_example src/main.cpp)
 target_link_libraries(vulkan_app_example PRIVATE vulkan_app)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Vulkano
 
-Minimal C++20 project demonstrating an icosphere mesh generator.
+Minimal C++20 project demonstrating an icosphere mesh generator and a basic GLFW/Vulkan application.
 
 ## Build
 
 ```
 cmake -S . -B build
 cmake --build build
+```
+
+## Run
+
+```
+./build/vulkan_app_example
 ```
 
 ## Test

--- a/include/vulkan_app/application.hpp
+++ b/include/vulkan_app/application.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <vector>
+
+#include <vulkan/vulkan.h>
+#include <GLFW/glfw3.h>
+
+namespace vulkan_app {
+
+class Application final {
+public:
+    Application();
+    ~Application() noexcept;
+    Application(const Application &) = delete;
+    Application &operator=(const Application &) = delete;
+
+    void run();
+
+private:
+    void init_window();
+    void init_vulkan();
+    void main_loop();
+
+    GLFWwindow *window{};
+    VkInstance instance{};
+};
+
+} // namespace vulkan_app

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,0 +1,117 @@
+#include <stdexcept>
+#include <vector>
+
+#include <vulkan/vulkan.h>
+#include <GLFW/glfw3.h>
+
+#include <vulkan_app/application.hpp>
+
+namespace vulkan_app {
+namespace {
+#ifdef NDEBUG
+constexpr bool enable_validation {false};
+#else
+constexpr bool enable_validation {true};
+#endif
+
+const std::vector<const char *> validation_layers {"VK_LAYER_KHRONOS_validation"};
+
+bool check_validation_layer_support() {
+    std::uint32_t layer_count {0};
+    vkEnumerateInstanceLayerProperties(&layer_count, nullptr);
+    std::vector<VkLayerProperties> available(layer_count);
+    vkEnumerateInstanceLayerProperties(&layer_count, available.data());
+    for (const char *name : validation_layers) {
+        bool found {false};
+        for (const auto &prop : available) {
+            if (std::string_view {prop.layerName} == name) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::vector<const char *> required_extensions() {
+    std::uint32_t count {0};
+    const char **ext = glfwGetRequiredInstanceExtensions(&count);
+    std::vector<const char *> extensions(ext, ext + count);
+    if (enable_validation) {
+        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    }
+    return extensions;
+}
+
+} // namespace
+
+Application::Application() {
+    init_window();
+    init_vulkan();
+}
+
+Application::~Application() noexcept {
+    vkDestroyInstance(instance, nullptr);
+    glfwDestroyWindow(window);
+    glfwTerminate();
+}
+
+void Application::run() {
+    main_loop();
+}
+
+void Application::init_window() {
+    if (glfwInit() == 0) {
+        throw std::runtime_error {"Failed to initialise GLFW"};
+    }
+    glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+    window = glfwCreateWindow(800, 600, "Vulkan", nullptr, nullptr);
+    if (window == nullptr) {
+        glfwTerminate();
+        throw std::runtime_error {"Failed to create GLFW window"};
+    }
+}
+
+void Application::init_vulkan() {
+    if (enable_validation && !check_validation_layer_support()) {
+        throw std::runtime_error {"Validation layers requested but not available"};
+    }
+
+    VkApplicationInfo app_info {};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "VulkanApp";
+    app_info.applicationVersion = VK_MAKE_API_VERSION(0, 1, 0, 0);
+    app_info.pEngineName = "NoEngine";
+    app_info.engineVersion = VK_MAKE_API_VERSION(0, 1, 0, 0);
+    app_info.apiVersion = VK_API_VERSION_1_2;
+
+    auto extensions = required_extensions();
+
+    VkInstanceCreateInfo create_info {};
+    create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    create_info.pApplicationInfo = &app_info;
+    create_info.enabledExtensionCount = static_cast<std::uint32_t>(extensions.size());
+    create_info.ppEnabledExtensionNames = extensions.data();
+
+    if (enable_validation) {
+        create_info.enabledLayerCount = static_cast<std::uint32_t>(validation_layers.size());
+        create_info.ppEnabledLayerNames = validation_layers.data();
+    } else {
+        create_info.enabledLayerCount = 0U;
+    }
+
+    if (vkCreateInstance(&create_info, nullptr, &instance) != VK_SUCCESS) {
+        throw std::runtime_error {"Failed to create Vulkan instance"};
+    }
+}
+
+void Application::main_loop() {
+    while (glfwWindowShouldClose(window) == 0) {
+        glfwPollEvents();
+    }
+}
+
+} // namespace vulkan_app

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,7 @@
-#include <iostream>
-
-#include <vulkan_app/icosphere.hpp>
+#include <vulkan_app/application.hpp>
 
 int main() {
-    const auto mesh {vulkan_app::make_icosphere(0)};
-    std::cout << "vertices: " << mesh.vertices.size() << '\n';
+    vulkan_app::Application app{};
+    app.run();
     return 0;
 }


### PR DESCRIPTION
## Summary
- integrate GLFW and Vulkan into build
- add Application class to create window and Vulkan instance
- update example and docs

## Testing
- `cmake -S . -B build` *(fails: unable to fetch glm dependency, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e1c8a4f483279c7cfc56e14c5dae